### PR TITLE
fix(pwd.c, single_builtin.c, child.c): now pwd works without the need…

### DIFF
--- a/include/builtin.h
+++ b/include/builtin.h
@@ -37,9 +37,6 @@ int				return_errors(int return_value, int message,
 int				cd_builtin(t_command_exec *node, t_utils *utils,
 					int pwd_emplacement, int pwd_old_emplacement);
 
-//pwd.c
-int				pwd_builtin(t_command_exec *node, t_utils *utils, int i, int j);
-
 //echo.c
 int				echo_builtin(t_command_exec *node, bool newline, int i);
 
@@ -58,7 +55,7 @@ unsigned int	exit_builtin(t_command_exec *node, t_utils *utils);
 int				export_builtin(t_command_exec *node, t_utils *utils, size_t i);
 
 //pwd.c
-int				pwd_builtin(t_command_exec *node, t_utils *utils, int i, int j);
+int				pwd_builtin(t_command_exec *node);
 
 //unset.c
 //static int env_len(char **env);

--- a/srcs/builtin/pwd.c
+++ b/srcs/builtin/pwd.c
@@ -11,7 +11,7 @@
 /* ************************************************************************** */
 
 #include "builtin.h"
-#include "minishell.h"
+#include "return_error.h"
 
 // Check if we are dealing with an option or an argument.
 static int	option_checker(char **cmd_parts)
@@ -32,29 +32,26 @@ static int	option_checker(char **cmd_parts)
 // content then return 0 else it would return 1
 // TODL KEEP IN MIND J = 4!!!!!!!!
 
-int	pwd_builtin(t_command_exec *node, t_utils *utils, int i, int j)
+int	pwd_builtin(t_command_exec *node)
 {
-	j = 4;
-	if (!node->cmd_parts || !node->cmd_parts[0])
-		return (EXIT_FAILURE);
+	char *cwd;
+
+	cwd = NULL;
 	if (node->cmd_parts[1])
 	{
 		if (option_checker(node->cmd_parts))
 			return (2);
 	}
-	while (utils->env[i])
+	cwd = getcwd(NULL, 0);
+	if(!cwd)
 	{
-		if (!ft_strncmp(utils->env[i], "PWD=", 4))
-		{
-			while (utils->env[i][j])
-			{
-				ft_printfd("%c", utils->env[i][j]);
-				j++;
-			}
-			ft_printf("\n");
-			return (EXIT_SUCCESS);
-		}
-		i++;
+		ft_printfd("minishell: pwd: error retrieving current directory");
+		ft_printfd(": getcwd: cannot access parent directories:");
+		ft_printfd(" No such file or directory\n");
+		return(RETURN_FAILURE);
 	}
-	return (EXIT_FAILURE);
+	ft_printf("%s\n", cwd);
+	free(cwd);
+	cwd = NULL;
+	return (EXIT_SUCCESS);
 }

--- a/srcs/exec/child.c
+++ b/srcs/exec/child.c
@@ -29,7 +29,7 @@ static int	built_in_child(t_command_exec *node, t_utils *utils)
 	else if (!ft_strcmp(node->cmd_parts[0], "echo"))
 		utils->last_return = ((echo_builtin(node, TRUE, 1)));
 	else if (!ft_strcmp(node->cmd_parts[0], "pwd"))
-		utils->last_return = ((pwd_builtin(node, utils, 0, 4)));
+		utils->last_return = ((pwd_builtin(node)));
 	else if (!ft_strcmp(node->cmd_parts[0], "export"))
 		utils->last_return = ((export_builtin(node, utils, 1)));
 	else if (!ft_strcmp(node->cmd_parts[0], "unset"))

--- a/srcs/exec/child_maker.c
+++ b/srcs/exec/child_maker.c
@@ -43,8 +43,8 @@ static int	wait_for_children_and_cleanup(t_utils *utils, int status,
 		}
 		pid = wait(&status);
 	}
-	pipe_fd[0] = 0;
-	//close(pipe_fd[0]);
+	if(utils->previous_pipes == -42)
+		close(pipe_fd[0]);
 	return (EXIT_SUCCESS);
 }
 // is previous pipe exist if yes is it not the last cmd?

--- a/srcs/exec/single_builtin.c
+++ b/srcs/exec/single_builtin.c
@@ -64,7 +64,7 @@ int	single_built_in(t_command_exec *node, t_utils *utils)
 	else if (!ft_strcmp(node->cmd_parts[0], "echo"))
 		utils->last_return = (echo_builtin(node, TRUE, 1));
 	else if (!ft_strcmp(node->cmd_parts[0], "pwd"))
-		utils->last_return = (pwd_builtin(node, utils, 0, 4));
+		utils->last_return = (pwd_builtin(node));
 	else if (!ft_strcmp(node->cmd_parts[0], "export"))
 		utils->last_return = (export_builtin(node, utils, 1));
 	else if (!ft_strcmp(node->cmd_parts[0], "unset"))


### PR DESCRIPTION
… to check inside of the env it also mean that if PWD does not exist in the env then it will still be able to find where the user is at the moment | fix_pipes(child_maker.c): fixed a logical error that made the pipe[0] to not close properly when it is needed