### PR TITLE
Export env

### DIFF
--- a/include/builtin.h
+++ b/include/builtin.h
@@ -54,6 +54,10 @@ unsigned int	exit_builtin(t_command_exec *node, t_utils *utils);
 //export.c
 int				export_builtin(t_command_exec *node, t_utils *utils, size_t i);
 
+//export_utils.c
+int	is_variable_already_in_env(t_utils *utils, char *variable_name,
+	size_t i, bool is_equal);
+
 //pwd.c
 int				pwd_builtin(t_command_exec *node);
 

--- a/include/builtin.h
+++ b/include/builtin.h
@@ -57,6 +57,8 @@ int				export_builtin(t_command_exec *node, t_utils *utils, size_t i);
 //export_utils.c
 int	is_variable_already_in_env(t_utils *utils, char *variable_name,
 	size_t i, bool is_equal);
+char	*assign_variable_name(char *cmd, char *variable_name, size_t i,
+		size_t j);
 
 //pwd.c
 int				pwd_builtin(t_command_exec *node);

--- a/include/builtin.h
+++ b/include/builtin.h
@@ -37,9 +37,6 @@ int				return_errors(int return_value, int message,
 int				cd_builtin(t_command_exec *node, t_utils *utils,
 					int pwd_emplacement, int pwd_old_emplacement);
 
-//pwd.c
-int				pwd_builtin(t_command_exec *node, t_utils *utils, int i, int j);
-
 //echo.c
 int				echo_builtin(t_command_exec *node, bool newline, int i);
 
@@ -58,7 +55,7 @@ unsigned int	exit_builtin(t_command_exec *node, t_utils *utils);
 int				export_builtin(t_command_exec *node, t_utils *utils, size_t i);
 
 //pwd.c
-int				pwd_builtin(t_command_exec *node, t_utils *utils, int i, int j);
+int				pwd_builtin(t_command_exec *node);
 
 //unset.c
 //static int env_len(char **env);

--- a/minishell.mk
+++ b/minishell.mk
@@ -87,6 +87,7 @@ override BUILTINSRC := \
 	exit \
 	exit_utils \
 	export \
+	export_utils \
 	pwd \
 	unset \
 

--- a/srcs/builtin/echo.c
+++ b/srcs/builtin/echo.c
@@ -24,6 +24,7 @@ static bool pass_n_flags(t_command_exec *node, int *index_print, int i)
 {
 	if (!node->cmd_parts[*index_print])
 		return(RETURN_SUCCESS);
+	
 	while (node->cmd_parts[*index_print] && ft_strncmp(node->cmd_parts[*index_print], "-n", 2) == 0 )
 		{
 			while(node->cmd_parts[*index_print][i])
@@ -32,8 +33,9 @@ static bool pass_n_flags(t_command_exec *node, int *index_print, int i)
 					i++;
 				else 
 				{
-					return(RETURN_SUCCESS);
+					break;
 				}
+			
 			}
 			i = 2;
 			*index_print += 1;
@@ -94,7 +96,7 @@ int	echo_builtin(t_command_exec *node, bool newline, int i)
 		i++;
 		if (node->cmd_parts[i])
 		{
-			if (ft_printf(" ") < 0)
+			if (ft_printf("") < 0) //tocheck
 				return (1);
 		}
 	}

--- a/srcs/builtin/env.c
+++ b/srcs/builtin/env.c
@@ -21,10 +21,14 @@ int	env_builtin(t_command_exec *node, t_utils *utils, size_t i)
 		ft_printfd("minishell: env: No arguments or options required\n");
 		return (EXIT_FAILURE);
 	}
-	while (i != utils->size_env)
+	if(utils->env)
 	{
-		ft_printf("%s\n", utils->env[i]);
-		i++;
+		while (utils->env[i])
+		{
+			if(ft_strchr(utils->env[i], '='))
+				ft_printf("%s\n", utils->env[i]);
+			i++;
+		}
 	}
 	return (EXIT_SUCCESS);
 }

--- a/srcs/builtin/export.c
+++ b/srcs/builtin/export.c
@@ -11,6 +11,8 @@
 /* ************************************************************************** */
 
 #include "../include/builtin.h"
+#include "parsing.h"
+#include "return_error.h"
 
 // compare content of env to check if it hold
 // the same name as the concerned arg entered with export
@@ -94,6 +96,28 @@ static int	equal_sign_case(t_utils *utils, char *cmd, char *variable_name,
 	}
 	return (RETURN_SUCCESS);
 }
+//if no args are provided then we print on the stdout
+//the env in the way that bash does
+//including the variables that doesnt have any values yet
+static void no_args_case(t_utils *utils, size_t i, size_t j)
+{
+	while (utils->env[i])
+	{
+		ft_printf("declare -x ");
+		while(utils->env[i][j])
+		{
+			ft_printf("%c", utils->env[i][j]);
+			if(utils->env[i][j] == '=' && utils->env[i][j+1])
+				ft_printf("\"");
+			j++;
+		}
+		if(utils->env[i][j-1] != '=')
+			ft_printf("\"");
+		ft_printf("\n");
+		j = 0;
+		i++;
+	}
+}
 
 // here we gonna check if we do at least have an argument(WIP)
 // then we check browse all the args until we reached the end
@@ -111,8 +135,8 @@ int	export_builtin(t_command_exec *node, t_utils *utils, size_t i)
 {
 	if (!node->cmd_parts[1])
 	{
-		ft_printfd("minishell: export: require an argument: \n");
-		return (RETURN_FAILURE);
+		no_args_case(utils, 0, 0);
+		return(RETURN_SUCCESS);
 	}
 	while (node->cmd_parts[i])
 	{

--- a/srcs/builtin/export.c
+++ b/srcs/builtin/export.c
@@ -99,7 +99,7 @@ static int	equal_sign_case(t_utils *utils, char *cmd, char *variable_name,
 //if no args are provided then we print on the stdout
 //the env in the way that bash does
 //including the variables that doesnt have any values yet
-static void no_args_case(t_utils *utils, size_t i, size_t j)
+static void no_args_case(t_utils *utils, size_t i, size_t j, bool empty_value)
 {
 	while (utils->env[i])
 	{
@@ -107,12 +107,16 @@ static void no_args_case(t_utils *utils, size_t i, size_t j)
 		while(utils->env[i][j])
 		{
 			ft_printf("%c", utils->env[i][j]);
-			if(utils->env[i][j] == '=' && utils->env[i][j+1])
+			if(utils->env[i][j] == '=')
+			{
 				ft_printf("\"");
+				empty_value = FALSE;
+			}
 			j++;
 		}
-		if(utils->env[i][j-1] != '=')
+		if(!empty_value)
 			ft_printf("\"");
+		empty_value = TRUE;
 		ft_printf("\n");
 		j = 0;
 		i++;
@@ -135,7 +139,7 @@ int	export_builtin(t_command_exec *node, t_utils *utils, size_t i)
 {
 	if (!node->cmd_parts[1])
 	{
-		no_args_case(utils, 0, 0);
+		no_args_case(utils, 0, 0, TRUE);
 		return(RETURN_SUCCESS);
 	}
 	while (node->cmd_parts[i])

--- a/srcs/builtin/export.c
+++ b/srcs/builtin/export.c
@@ -14,29 +14,8 @@
 #include "parsing.h"
 #include "return_error.h"
 
-// utils function that isolate the name of the variable
-// in case of a cmd with an = sign, for further processing
-// in equal_sign_case
-// increment index until we get to the =sign, malloc
-// enough space to variable_name thanks to that index then fill
-// the same variable with the rightful characters then return the result
 
-static char	*assign_variable_name(char *cmd, char *variable_name, size_t i,
-		size_t j)
-{
-	while (cmd[i] != '=')
-		i++;
-	variable_name = malloc(i + 1 * sizeof(char));
-	if (!variable_name)
-		return (NULL);
-	while (j != i)
-	{
-		variable_name[j] = cmd[j];
-		j++;
-	}
-	variable_name[j] = '\0';
-	return (variable_name);
-}
+
 
 // if equal sign it mean what is at the right side
 // is the result of the said variable
@@ -130,18 +109,41 @@ static int	no_equal_sign_case(t_utils *utils, char *cmd,
 
 // TODO? if just export do like bash or follow manual? aka ask for arguments
 
+
+//chiffre lettre underscore
+static int error_checker(t_command_exec *node, size_t i)
+{
+	size_t j;
+
+	j = 0;
+	if (node->cmd_parts[i][0] == '=' || (!ft_isalpha(node->cmd_parts[i][0])
+			&& (node->cmd_parts[i][0] != '_')))
+	{
+		return (RETURN_FAILURE);
+	}
+	while((node->cmd_parts[i][j] != '=' && node->cmd_parts[i][j]))
+	{
+		if(!ft_isalnum(node->cmd_parts[i][j]) && node->cmd_parts[i][j] != '_')
+			return(RETURN_FAILURE);
+		j++;
+	}
+	return(RETURN_SUCCESS);
+}
+
 int	export_builtin(t_command_exec *node, t_utils *utils, size_t i)
 {
+	int return_value;
+
+	return_value = RETURN_SUCCESS;
 	if (!node->cmd_parts[1])
 		return(no_args_case(utils, 0, 0, TRUE));
 	while (node->cmd_parts[i])
 	{
-		if (node->cmd_parts[i][0] == '=' || (!ft_isalpha(node->cmd_parts[i][0])
-				&& (node->cmd_parts[i][0] != '_')))
+		if(error_checker(node, i))
 		{
 			ft_printfd("minishell: export: '%s': not a valid identifier\n",
 				node->cmd_parts[i]);
-			return (RETURN_FAILURE);
+			return_value = RETURN_FAILURE;
 		}
 		else if (ft_strchr(node->cmd_parts[i], '='))
 		{
@@ -155,5 +157,5 @@ int	export_builtin(t_command_exec *node, t_utils *utils, size_t i)
 		}
 		i++;
 	}
-	return (RETURN_SUCCESS);
+	return (return_value);
 }

--- a/srcs/builtin/export.c
+++ b/srcs/builtin/export.c
@@ -30,6 +30,7 @@ static int	equal_sign_case(t_utils *utils, char *cmd, char *variable_name,
 		int existing_variable_emp)
 {
 	variable_name = assign_variable_name(cmd, NULL, 0, 0);
+	ft_printfd("variable name = %s\n",variable_name); //TODL
 	if (!variable_name)
 		return (MALLOC_ERROR);
 	existing_variable_emp = is_variable_already_in_env(utils, variable_name, 0,

--- a/srcs/builtin/export_utils.c
+++ b/srcs/builtin/export_utils.c
@@ -23,3 +23,27 @@ int	is_variable_already_in_env(t_utils *utils, char *variable_name,
 		free(variable_name);
 	return (FALSE);
 }
+
+// utils function that isolate the name of the variable
+// in case of a cmd with an = sign, for further processing
+// in equal_sign_case
+// increment index until we get to the =sign, malloc
+// enough space to variable_name thanks to that index then fill
+// the same variable with the rightful characters then return the result
+
+char	*assign_variable_name(char *cmd, char *variable_name, size_t i,
+		size_t j)
+{
+	while (cmd[i] != '=')
+		i++;
+	variable_name = malloc(i + 1 * sizeof(char));
+	if (!variable_name)
+		return (NULL);
+	while (j != i)
+	{
+		variable_name[j] = cmd[j];
+		j++;
+	}
+	variable_name[j] = '\0';
+	return (variable_name);
+}

--- a/srcs/builtin/export_utils.c
+++ b/srcs/builtin/export_utils.c
@@ -1,0 +1,25 @@
+#include "../include/builtin.h"
+#include "parsing.h"
+
+// compare content of env to check if it hold
+// the same name as the concerned arg entered with export
+
+int	is_variable_already_in_env(t_utils *utils, char *variable_name,
+		size_t i, bool is_equal)
+{
+	while (utils->env[i])
+	{
+		if (!ft_strncmp(variable_name, utils->env[i], ft_strlen(variable_name))
+			&& (utils->env[i][ft_strlen(variable_name)] == '='))
+		{
+			if (is_equal)
+				free(variable_name);
+			return (i);
+		}
+		else
+			i++;
+	}
+	if (is_equal)
+		free(variable_name);
+	return (FALSE);
+}

--- a/srcs/builtin/export_utils.c
+++ b/srcs/builtin/export_utils.c
@@ -7,10 +7,13 @@
 int	is_variable_already_in_env(t_utils *utils, char *variable_name,
 		size_t i, bool is_equal)
 {
+    int len;
+
+    len = ft_strlen(variable_name);
 	while (utils->env[i])
 	{
-		if (!ft_strncmp(variable_name, utils->env[i], ft_strlen(variable_name))
-			&& (utils->env[i][ft_strlen(variable_name)] == '='))
+        if (!ft_strncmp(variable_name, utils->env[i], len) &&
+			(utils->env[i][len] == '=' || utils->env[i][len] == '\0'))
 		{
 			if (is_equal)
 				free(variable_name);

--- a/srcs/builtin/pwd.c
+++ b/srcs/builtin/pwd.c
@@ -11,7 +11,7 @@
 /* ************************************************************************** */
 
 #include "builtin.h"
-#include "minishell.h"
+#include "return_error.h"
 
 // Check if we are dealing with an option or an argument.
 static int	option_checker(char **cmd_parts)
@@ -32,29 +32,26 @@ static int	option_checker(char **cmd_parts)
 // content then return 0 else it would return 1
 // TODL KEEP IN MIND J = 4!!!!!!!!
 
-int	pwd_builtin(t_command_exec *node, t_utils *utils, int i, int j)
+int	pwd_builtin(t_command_exec *node)
 {
-	j = 4;
-	if (!node->cmd_parts || !node->cmd_parts[0])
-		return (EXIT_FAILURE);
+	char *cwd;
+
+	cwd = NULL;
 	if (node->cmd_parts[1])
 	{
 		if (option_checker(node->cmd_parts))
 			return (2);
 	}
-	while (utils->env[i])
+	cwd = getcwd(NULL, 0);
+	if(!cwd)
 	{
-		if (!ft_strncmp(utils->env[i], "PWD=", 4))
-		{
-			while (utils->env[i][j])
-			{
-				ft_printfd("%c", utils->env[i][j]);
-				j++;
-			}
-			ft_printf("\n");
-			return (EXIT_SUCCESS);
-		}
-		i++;
+		ft_printfd("minishell: pwd: error retrieving current directory");
+		ft_printfd(": getcwd: cannot access parent directories:");
+		ft_printfd(" No such file or directory\n");
+		return(RETURN_FAILURE);
 	}
-	return (EXIT_FAILURE);
+	ft_printf("%s\n", cwd);
+	free(cwd);
+	cwd = NULL;
+	return (EXIT_SUCCESS);
 }

--- a/srcs/exec/child.c
+++ b/srcs/exec/child.c
@@ -29,7 +29,7 @@ static int	built_in_child(t_command_exec *node, t_utils *utils)
 	else if (!ft_strcmp(node->cmd_parts[0], "echo"))
 		utils->last_return = ((echo_builtin(node, TRUE, 1)));
 	else if (!ft_strcmp(node->cmd_parts[0], "pwd"))
-		utils->last_return = ((pwd_builtin(node, utils, 0, 4)));
+		utils->last_return = ((pwd_builtin(node)));
 	else if (!ft_strcmp(node->cmd_parts[0], "export"))
 		utils->last_return = ((export_builtin(node, utils, 1)));
 	else if (!ft_strcmp(node->cmd_parts[0], "unset"))

--- a/srcs/exec/child_maker.c
+++ b/srcs/exec/child_maker.c
@@ -43,6 +43,8 @@ static int	wait_for_children_and_cleanup(t_utils *utils, int status,
 		}
 		pid = wait(&status);
 	}
+	//	if(utils->num_nodes != 1)
+	//close(utils->previous_pipes);
 	if(utils->previous_pipes == -42)
 		close(pipe_fd[0]);
 	return (EXIT_SUCCESS);

--- a/srcs/exec/child_maker.c
+++ b/srcs/exec/child_maker.c
@@ -43,8 +43,8 @@ static int	wait_for_children_and_cleanup(t_utils *utils, int status,
 		}
 		pid = wait(&status);
 	}
-	pipe_fd[0] = 0;
-	//close(pipe_fd[0]);
+	if(utils->previous_pipes == -42)
+		close(pipe_fd[0]);
 	return (EXIT_SUCCESS);
 }
 // is previous pipe exist if yes is it not the last cmd?

--- a/srcs/exec/single_builtin.c
+++ b/srcs/exec/single_builtin.c
@@ -64,7 +64,7 @@ int	single_built_in(t_command_exec *node, t_utils *utils)
 	else if (!ft_strcmp(node->cmd_parts[0], "echo"))
 		utils->last_return = (echo_builtin(node, TRUE, 1));
 	else if (!ft_strcmp(node->cmd_parts[0], "pwd"))
-		utils->last_return = (pwd_builtin(node, utils, 0, 4));
+		utils->last_return = (pwd_builtin(node));
 	else if (!ft_strcmp(node->cmd_parts[0], "export"))
 		utils->last_return = (export_builtin(node, utils, 1));
 	else if (!ft_strcmp(node->cmd_parts[0], "unset"))


### PR DESCRIPTION
Pwd now works without depending on the ENV content, also export now does behave as bash does when no args are provided added some lisibility ENV does not show empty variable error checker function a new export_utils.c file and better logics in export.c